### PR TITLE
Add PLCIpAddress property to S7Client

### DIFF
--- a/Sharp7/S7Client.cs
+++ b/Sharp7/S7Client.cs
@@ -698,6 +698,7 @@ namespace Sharp7
 
 		public int ConnectTo(string Address, int Rack, int Slot)
 		{
+			PLCIpAddress = Address;
 			UInt16 RemoteTSAP = (UInt16)((ConnType << 8) + (Rack * 0x20) + Slot);
 			SetConnectionParams(Address, 0x0100, RemoteTSAP);
 			return Connect();
@@ -2267,6 +2268,8 @@ namespace Sharp7
 				_PduSizeRequested = value;       
 			}
 		}
+
+		public string PLCIpAddress { get; private set; }
 
 		public int PLCPort
 		{


### PR DESCRIPTION
Ip address property is needed on the S7Client. For exp.: To write a log about which PLC is getting an error when working with multiple PLC